### PR TITLE
Use getNode instead of findNode when applying

### DIFF
--- a/src/apply/apply.js
+++ b/src/apply/apply.js
@@ -7,7 +7,7 @@ module.exports = applyPatches;
 var handlers = {
 
 	event: function(patch, document, patchOptions){
-		var node = nodeRoute.findNode(patch.route);
+		var node = nodeRoute.getNode(patch.route);
 		node[patch.action](patch.event, patchOptions.eventHandler);
 	},
 
@@ -16,17 +16,17 @@ var handlers = {
 	},
 
 	text: function(patch){
-		var node = nodeRoute.findNode(patch.route);
+		var node = nodeRoute.getNode(patch.route);
 		node.nodeValue = patch.value;
 	},
 
 	attribute: function(patch){
-		var el = nodeRoute.findNode(patch.route);
+		var el = nodeRoute.getNode(patch.route);
 		setAttribute(el, patch.attr, patch.value);
 	},
 
 	prop: function(patch){
-		var el = nodeRoute.findNode(patch.route);
+		var el = nodeRoute.getNode(patch.route);
 		if(!el) { return; }
 		el[patch.prop] = patch.value;
 	},
@@ -38,23 +38,26 @@ var handlers = {
 
 	insert: function(patch, document, patchOptions){
 		var node = deserialize(patch.node, false, patchOptions);
-		var parent = nodeRoute.findNode(patch.route);
+		var parent = nodeRoute.getNode(patch.route);
 
 		if(patch.ref) {
 			var ref = nodeRoute.findNode("0."+patch.ref, parent);
 			parent.insertBefore(node, ref);
+			nodeRoute.purgeSiblings(node);
 		} else {
 			parent.appendChild(node);
 		}
 	},
 
 	remove: function(patch){
-		var parent = nodeRoute.findNode(patch.route);
-		var node = nodeRoute.findNode(patch.child);
+		var parent = nodeRoute.getNode(patch.route);
+		var node = nodeRoute.getNode(patch.child);
 
 		if(!node) {
 			return;
 		}
+		nodeRoute.purgeSiblings(node);
+		nodeRoute.purgeNode(node);
 		parent.removeChild(node);
 	}
 

--- a/src/apply/apply_test.js
+++ b/src/apply/apply_test.js
@@ -1,9 +1,11 @@
 var apply = require("dom-patch/apply");
+var nodeRoute = require("node-route");
 var QUnit = require("steal-qunit");
 
 QUnit.module("dom-patch/apply", {
 	setup: function(){
 		this.testArea = document.getElementById("qunit-test-area");
+		nodeRoute.purgeCache();
 	},
 	teardown: function(){
 		this.testArea.innerHTML = "";
@@ -58,4 +60,25 @@ QUnit.test("can patch weird attribute names", function(){
 	apply(document, patches);
 
 	QUnit.equal(this.testArea.firstChild.getAttribute("[restaurant]"), "tacos", "special character attribute was set");
+});
+
+QUnit.test("inserts purge the sibling route table", function(){
+	var ul = document.createElement("ul");
+	var div = document.createElement("div");
+	this.testArea.appendChild(ul);
+	this.testArea.appendChild(div);
+
+
+	// This will cause the div to be cached.
+	var id = nodeRoute.getID(div);
+
+	var nodeS = [];
+	nodeS[3] = "SPAN";
+	var patches = [
+		{"type":"insert","node":nodeS,"route":id.substr(0, id.length - 2),"ref":"1"}
+	];
+
+	apply(document, patches);
+
+	QUnit.notEqual(nodeRoute.nodeCache[id], div, "not the div");
 });


### PR DESCRIPTION
When applying patches, use `nodeRoute.getNode` to look up nodes by id.
This method looks in the cache first. To use this we must be sure to
purge nodes and sibiling nodes when doing insertBefore and removeChild.
Adds a test to confirm this is working.
