### PR TITLE
Make compatible with can 3.0

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,7 +1,7 @@
 var stealTools = require("steal-tools");
 
 stealTools.export({
-	system: {
+	steal: {
 		config: __dirname + "/package.json!npm"
 	},
 	outputs: {

--- a/package.json
+++ b/package.json
@@ -29,20 +29,20 @@
     "main": "patch.js",
     "directories": {
       "lib": "src"
-    },
-    "npmIgnore": [
-      "testee"
-    ]
+    }
   },
   "dependencies": {
-    "can": "^3.2.2",
     "node-route": "^1.0.0"
   },
   "devDependencies": {
-    "can-simple-dom": "^1.0.2",
-    "steal": "^0.16.43",
-    "steal-qunit": "0.1.4",
-    "steal-tools": "^0.16.8",
+    "can-map": "^3.0.6",
+    "can-simple-dom": "^1.0.6",
+    "can-stache": "^3.0.21",
+    "can-util": "^3.3.5",
+    "can-vdom": "^3.0.3",
+    "steal": "^1.0.0",
+    "steal-qunit": "^1.0.0",
+    "steal-tools": "^1.0.0",
     "testee": "^0.3.0"
   }
 }

--- a/src/overrides/overrides_test.js
+++ b/src/overrides/overrides_test.js
@@ -1,13 +1,15 @@
 var QUnit = require("steal-qunit");
-var can = require("can");
 var simpleDOM = require("can-simple-dom");
+var Map = require("can-map");
 var Node = require("can-simple-dom/simple-dom/document/node")["default"];
-require("can/util/vdom/build_fragment/");
-require("can/view/stache/");
+var DOCUMENT = require("can-util/dom/document/document");
+var MO = require("can-util/dom/mutation-observer/mutation-observer");
+var stache = require("can-stache");
 var nodeRoute = require("node-route");
 var markAsInDocument = require("./util/mark_in_document");
 
 var patch = require("dom-patch");
+
 
 QUnit.module("dom-patch overrides", {
 	setup: function(){
@@ -15,37 +17,41 @@ QUnit.module("dom-patch overrides", {
 
 		this.oldPostMessage = window.postMessage;
 		window.postMessage = function(){};
-		this.doc = can.document = new simpleDOM.Document();
+		this.doc = new simpleDOM.Document();
+		this.oldDoc = DOCUMENT();
+		this.mo = MO();
+		DOCUMENT(this.doc);
+		MO(null);
 
 		this.patch(this.doc, function(){});
-
 		markAsInDocument(this.doc.documentElement);
 	},
-	teardown: function(){
-		window.postMessage = this.oldPostMessage;
-		can.document = window.document;
-
+	teardown: function(assert){
 		this.patch.deregister();
+		window.postMessage = this.oldPostMessage;
+		DOCUMENT(this.oldDoc);
+		MO(this.mo);
+
 	}
 });
 
 QUnit.test("Nodes appended to the DOM are in the document", function(){
-	var template = can.stache("<div><span>hello world</span></div>");
+	var template = stache("<div><span>hello world</span></div>");
 	var frag = template();
+	var span = frag.firstChild.firstChild;
 	this.doc.documentElement.appendChild(frag);
 
-	var span = frag.firstChild.firstChild;
 	equal(span.inDocument, true, "span is in the document");
 });
 
 QUnit.test("Inserting a sibling will reset ids", function(){
-	var map = new can.Map({name:"matthew"});
-	var template = can.stache("<div><div><ul><li><span id='hello'>{{name}}</span></li></ul></div></div>");
+	var map = new Map({name:"matthew"});
+	var template = stache("<div><div><ul><li><span id='hello'>{{name}}</span></li></ul></div></div>");
 	var frag = template(map);
-	this.doc.documentElement.appendChild(frag);
-
 	var ul = frag.firstChild.firstChild.firstChild;
 	var firstLi = ul.firstChild;
+
+	this.doc.documentElement.appendChild(frag);
 
 	// Now we have 3 cached nodes, the first div, the first li and the span.
 	// If we insert a sibling li it should update the first li and the span.
@@ -57,14 +63,14 @@ QUnit.test("Inserting a sibling will reset ids", function(){
 });
 
 QUnit.test("Setting a TextNode will create an id", function(){
-	var template = can.stache("<div>{{name}}</div>");
-	var map = new can.Map({name:"matthew"});
+	var template = stache("<div>{{name}}</div>");
+	var map = new Map({name:"matthew"});
 	var frag = template(map);
 
+	var textNode = frag.firstChild.firstChild;
 	this.doc.documentElement.appendChild(frag);
 
 	map.attr("name", "wilbur");
 
-	var textNode = frag.firstChild.firstChild;
 	equal(nodeRoute.nodeCache["0.1.0"], textNode, "it is the text node");
 });

--- a/src/patch/patch_test.js
+++ b/src/patch/patch_test.js
@@ -2,19 +2,19 @@ var QUnit = require("steal-qunit");
 var loader = require("@loader");
 
 var patch = require("dom-patch");
-var simpleDOM = require("can-simple-dom");
+var makeDocument = require("can-vdom/make-document/make-document");
 var NodeProp = require("../node_prop");
 
 QUnit.module("dom-patch/patch", {
 	setup: function(done){
-		this.document = new simpleDOM.Document();
+		this.document = makeDocument();
 
 		this.testArea = this.document.createElement("div");
 		this.document.documentElement.appendChild(this.testArea);
 	},
 	teardown: function(){
-		this.testArea.innerHTML = "";
 		patch.deregister();
+		this.testArea.innerHTML = "";
 	}
 });
 

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -57,6 +57,9 @@ exports.register = function(callback){
 exports.unregister = function(callback){
 	if(arguments.length === 0) {
 		callbacks = [];
+		changedRoutes = {};
+		changes.length = 0;
+		globals.length = 0;
 		return;
 	}
 


### PR DESCRIPTION
This updates dom-patch to be compatible with can 3.0. This is the first step in making web-worker rendering compatible with can 3.0.