### PR TITLE
Allow collapsing of text nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/canjs/dom-patch#readme",
   "dependencies": {
-    "node-route": "^1.0.5"
+    "node-route": "^1.1.0"
   },
   "devDependencies": {
     "can-map": "^3.0.6",

--- a/src/overrides/insert.js
+++ b/src/overrides/insert.js
@@ -2,6 +2,7 @@ var schedule = require("../scheduler").schedule;
 var nodeRoute = require("node-route");
 var markAsInDocument = require("./util/mark_in_document");
 var inDocument = require("./util/in_document");
+var patchOpts = require("../patch/patch-options");
 var serialize = require("../node_serialization").serialize;
 
 var DOCUMENT_FRAGMENT_NODE = 11;
@@ -31,6 +32,7 @@ module.exports = function(Node){
 		var res = insertBefore.apply(this, arguments);
 
 		var parent = this;
+
 		children.forEach(function(child){
 			registerForDiff(child, parent, refIndex);
 		});

--- a/src/patch/patch-options.js
+++ b/src/patch/patch-options.js
@@ -1,0 +1,1 @@
+exports.collapseTextNodes = false;

--- a/src/patch/patch.js
+++ b/src/patch/patch.js
@@ -1,3 +1,4 @@
+var patchOptions = require("./patch-options");
 var scheduler = require("../scheduler");
 var markAsInDocument = require("../overrides/util/mark_in_document");
 
@@ -15,6 +16,13 @@ exports = module.exports = bind;
 exports.bind = bind;
 exports.unbind = unbind;
 exports.deregister = deregister;
+
+// Forward on the collapseTextNodes option to the scheduler.
+Object.defineProperty(exports, "collapseTextNodes", {
+	set: function(val){
+		patchOptions.collapseTextNodes = val;
+	}
+});
 
 // Used to keep track of documents we are listening to.
 var listeningDocs = [];

--- a/src/patch/patch_test.js
+++ b/src/patch/patch_test.js
@@ -76,3 +76,51 @@ QUnit.test("setting className is serialized as a node patch", function(patches){
 
 	QUnit.stop();
 });
+
+QUnit.module("dom-patch/patch {collapseTextNodes}", {
+	setup: function(done){
+		patch.collapseTextNodes = true;
+		this.document = makeDocument();
+
+		this.testArea = this.document.createElement("div");
+		this.document.documentElement.appendChild(this.testArea);
+	},
+	teardown: function(){
+		patch.deregister();
+		patch.collapseTextNodes = false;
+		this.testArea.innerHTML = "";
+	}
+});
+
+QUnit.test("Ignores consecutive TextNodes", function(){
+	var document = this.document;
+	var ta = this.testArea;
+
+	var count = 0;
+	patch(document, function(patches){
+		count++;
+
+		if(count === 1) {
+			// Changing the value should cause a text patch to come
+			// around next
+			tn2.nodeValue = "TWO";
+		} else if(count === 2) {
+			// test
+			QUnit.equal(patches.length, 1);
+			QUnit.equal(patches[0].nodeValue, "oneTWO");
+			QUnit.start();
+		}
+	});
+
+	ta.appendChild(document.createTextNode("one"));
+	var tn2 = document.createTextNode("two");
+	ta.appendChild(tn2);
+
+	var span = document.createElement("span");
+	ta.appendChild(span);
+
+	ta.appendChild(document.createTextNode("three"));
+	ta.appendChild(document.createTextNode("four"));
+
+	QUnit.stop();
+})


### PR DESCRIPTION
This enables the `collapseTextNodes` option to be set globally for
patches. Closes #19