### PR TITLE
Use a dictionary object as the serialized Node

### DIFF
--- a/src/node_serialization.js
+++ b/src/node_serialization.js
@@ -6,7 +6,7 @@ exports.serialize = nodeToObject;
 exports.deserialize = objectToNode;
 
 function nodeToObject(node){
-	var objNode = [], i;
+	var objNode = Object.create(null), i;
 
 	if (node.nodeType === 3) {
 		objNode[NodeProp.TEXT] = node.nodeValue;


### PR DESCRIPTION
Using a dictionary prevents problems when the object is then serialized
(and later deserialized) to JSON. Closes #24