### PR TITLE
Makes replaceChild operations handle fragments

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "can-map": "^3.0.6",
-    "can-simple-dom": "^1.0.6",
+    "can-simple-dom": "^1.0.10",
     "can-stache": "^3.0.21",
     "can-util": "^3.3.5",
     "can-vdom": "^3.0.3",

--- a/src/apply/apply.js
+++ b/src/apply/apply.js
@@ -43,7 +43,7 @@ var handlers = {
 
 	insert: function(patch, document, patchOptions){
 		var node = deserialize(patch.node, false, patchOptions);
-		var parent = nodeRoute.getNode(patch.route);
+		var parent = nodeRoute.getNode(patch.route, document);
 
 		if(patch.ref) {
 			var ref = nodeRoute.findNode("0."+patch.ref, parent);
@@ -56,14 +56,14 @@ var handlers = {
 
 	replace: function(patch, document, patchOptions){
 		var node = deserialize(patch.node, false, patchOptions);
-		var parent = nodeRoute.getNode(patch.route);
+		var parent = nodeRoute.getNode(patch.route, document);
 		var ref = nodeRoute.findNode("0."+patch.ref, parent);
 		parent.replaceChild(node, ref);
 	},
 
-	remove: function(patch){
+	remove: function(patch, document){
 		var parent = nodeRoute.getNode(patch.route);
-		var node = nodeRoute.getNode(patch.child);
+		var node = nodeRoute.getNode(patch.child, document);
 
 		if(!node) {
 			return;

--- a/src/node_prop.js
+++ b/src/node_prop.js
@@ -9,5 +9,6 @@ module.exports = {
 	CHECKED: 7,
 	SELECTED: 8,
 	EVENTS: 9,
-	CLASS: 10
+	CLASS: 10,
+	FRAGMENT: 11
 };

--- a/src/node_serialization.js
+++ b/src/node_serialization.js
@@ -1,8 +1,8 @@
 var NodeProp = require("./node_prop");
 var setAttribute = require("./setattribute");
+var has = Object.prototype.hasOwnProperty;
 
 exports.serialize = nodeToObject;
-
 exports.deserialize = objectToNode;
 
 function nodeToObject(node){
@@ -57,10 +57,10 @@ function objectToNode(objNode, insideSvg, diffOptions) {
 	}
 
 	var node, i;
-	if (objNode.hasOwnProperty(NodeProp.TEXT)) {
+	if (has.call(objNode, NodeProp.TEXT)) {
 		node = document.createTextNode(objNode[NodeProp.TEXT]);
-	} else if (objNode.hasOwnProperty(NodeProp.COMMENT)) {
-		node = document.createComment(objNode[COMMENT]);
+	} else if (has.call(objNode, NodeProp.COMMENT)) {
+		node = document.createComment(objNode[NodeProp.COMMENT]);
 	} else {
 		if (objNode[NodeProp.NODE_NAME] === 'svg' || insideSvg) {
 			node = document.createElementNS('http://www.w3.org/2000/svg', objNode[NodeProp.NODE_NAME]);

--- a/src/patch/patch.js
+++ b/src/patch/patch.js
@@ -28,6 +28,7 @@ Object.defineProperty(exports, "collapseTextNodes", {
 var listeningDocs = [];
 // Functions that when called will undo DOM wrapping.
 var overrideTeardowns = [];
+var _over = typeof Symbol === "function" ? Symbol("_override") : "__patch-override";
 
 
 /**
@@ -43,16 +44,22 @@ function bind(document, callback){
 	var Node = getNodeConstructor(document);
 
 	if(listeningDocs.indexOf(document) === -1) {
-		overrides.forEach(function(override){
-			var res = override(Node, document);
-			if(typeof res !== "undefined") {
-				overrideTeardowns.push(res);
-			}
-		});
+		if(!Node[_over]) {
+			overrides.forEach(function(override){
+				var res = override(Node, document);
+				if(typeof res !== "undefined") {
+					overrideTeardowns.push(res);
+				}
+			});
+			overrideTeardowns.push(function(){
+				Node[_over] = undefined;
+			});
+		}
 		markAsInDocument(document.documentElement);
 		listeningDocs.push(document);
 	}
 
+	Node[_over] = true;
 	scheduler.register(callback);
 }
 

--- a/src/patch/patch_test.js
+++ b/src/patch/patch_test.js
@@ -1,5 +1,4 @@
 var QUnit = require("steal-qunit");
-var loader = require("@loader");
 
 var patch = require("dom-patch");
 var makeDocument = require("can-vdom/make-document/make-document");

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,8 +1,7 @@
 var nodeRoute = require("node-route");
 var patchOpts = require("./patch/patch-options");
 
-var changedRoutes = {},
-	changes = [],
+var changes = [],
 	globals = [],
 	flushScheduled,
 	callbacks = [];
@@ -50,11 +49,10 @@ exports.flushChanges = function flushChanges(){
 		domChanges.push(data);
 	});
 
-	changedRoutes = {};
 	changes.length = 0;
 	globals.length = 0;
-
 	flushScheduled = false;
+	
 	callbacks.forEach(function(cb){
 		cb(domChanges);
 	});
@@ -67,7 +65,6 @@ exports.register = function(callback){
 exports.unregister = function(callback){
 	if(arguments.length === 0) {
 		callbacks = [];
-		changedRoutes = {};
 		changes.length = 0;
 		globals.length = 0;
 		return;

--- a/test/patch-and-apply_test.js
+++ b/test/patch-and-apply_test.js
@@ -1,0 +1,68 @@
+var QUnit = require("steal-qunit");
+
+var apply = require("dom-patch/apply");
+var patch = require("dom-patch");
+var makeDocument = require("can-vdom/make-document/make-document");
+var nodeRoute = require("node-route");
+
+function makeVdomArea() {
+	var doc = makeDocument();
+	var vdomTestArea = doc.createElement("div");
+	doc.documentElement.insertBefore(doc.createElement("head"),
+		doc.documentElement.firstChild);
+	doc.body.appendChild(vdomTestArea);
+	return {
+		document: doc,
+		vdomTestArea: vdomTestArea
+	};
+}
+
+QUnit.module("patch and apply", {
+	setup: function(done){
+		var area = makeVdomArea();
+		this.document = area.document;
+		this.vdomTestArea = area.vdomTestArea;
+
+		this.otherDocument = document.implementation.createHTMLDocument("Title");
+
+		// Clean it up, removing the doctype and other stuff
+		var docType = this.otherDocument.firstChild;
+		var html = docType.nextSibling;
+		docType.parentNode.removeChild(docType);
+		//html.removeChild(html.firstChild); // Remove the head
+
+		this.testArea = this.otherDocument.createElement("div");
+		this.otherDocument.body.appendChild(this.testArea);
+	},
+	teardown: function(){
+		patch.deregister();
+		this.testArea.innerHTML = "";
+	}
+});
+
+QUnit.test("Replacing with a DocumentFragment works", function(){
+	patch(this.document, function onpatches(patches){
+		// Purge the cache so we don't get wrong results.
+		nodeRoute.purgeCache();
+		apply(this.otherDocument, patches);
+
+		QUnit.equal(this.testArea.firstChild.nodeName, "UL", "the <ul> is first");
+		QUnit.equal(this.testArea.firstChild.nextSibling.nodeName, "DD", "the <dd> is next");
+
+		QUnit.start();
+	}.bind(this));
+
+	var first = this.document.createElement("span");
+	this.vdomTestArea.appendChild(first);
+
+	var frag = this.document.createDocumentFragment();
+	frag.appendChild(this.document.createElement("ul"));
+	var dd = this.document.createElement("dd");
+	dd.appendChild(this.document.createTextNode("some text"));
+	frag.appendChild(dd);
+
+	this.vdomTestArea.replaceChild(frag, first);
+
+
+	QUnit.stop();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
 require("dom-patch/src/overrides/overrides_test");
 require("dom-patch/src/patch/patch_test");
 require("dom-patch/src/apply/apply_test");
+require("dom-patch/test/patch-and-apply_test");


### PR DESCRIPTION
This change makes it so that .replaceChild(fragment, oldChild) will
result in a patch that includes a document fragment. Closes #26