### PR TITLE
Landscaper: Remove deprecated can-util methods and replace with can-globals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules/
 dist/
+package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 node_js: 8
+addons:
+  firefox: "latest-esr"
+  apt:
+    packages:
+      - "dbus-x11"
 script: npm test
 before_install:
   - "export DISPLAY=:99.0"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
     "build": "node build.js",
-	"debug:node": "node --inspect-brk node_modules/.bin/qunit src/patch/patch_test.js",
-	"test:node": "qunit src/patch/patch_test.js",
+    "debug:node": "node --inspect-brk node_modules/.bin/qunit src/patch/patch_test.js",
+    "test:node": "qunit src/patch/patch_test.js",
     "test:browser": "testee test/test.html --browsers firefox --reporter Spec",
-	"test": "npm run test:node && npm run test:browser"
+    "test": "npm run test:node && npm run test:browser"
   },
   "repository": {
     "type": "git",
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/canjs/dom-patch#readme",
   "dependencies": {
+    "can-globals": "^0.2.3",
     "node-route": "^1.2.0"
   },
   "devDependencies": {

--- a/src/overrides/overrides_test.js
+++ b/src/overrides/overrides_test.js
@@ -2,8 +2,8 @@ var QUnit = require("steal-qunit");
 var simpleDOM = require("can-simple-dom");
 var Map = require("can-map");
 var Node = require("can-simple-dom/simple-dom/document/node")["default"];
-var DOCUMENT = require("can-util/dom/document/document");
-var MO = require("can-util/dom/mutation-observer/mutation-observer");
+var DOCUMENT = require("can-globals/document/document");
+var globals = require("can-globals");
 var stache = require("can-stache");
 var nodeRoute = require("node-route");
 var markAsInDocument = require("./util/mark_in_document");
@@ -18,9 +18,8 @@ QUnit.module("dom-patch overrides", {
 		window.postMessage = function(){};
 		this.doc = new simpleDOM.Document();
 		this.oldDoc = DOCUMENT();
-		this.mo = MO();
 		DOCUMENT(this.doc);
-		MO(null);
+		globals.setKeyValue('MutationObserver', null);
 
 		this.patch(this.doc, function(){});
 		markAsInDocument(this.doc.documentElement);
@@ -29,7 +28,7 @@ QUnit.module("dom-patch overrides", {
 		this.patch.deregister();
 		window.postMessage = this.oldPostMessage;
 		DOCUMENT(this.oldDoc);
-		MO(this.mo);
+		globals.deleteKeyValue('MutationObserver');
 
 	}
 });


### PR DESCRIPTION
This pull request was created with [Landscaper](https://github.com/bitovi/landscaper).
The following code mods were used to create this PR:

1. **https://gist.github.com/imaustink/d1faff15b89df8fb7964c5d5c3945e72**

Please review this PR carefully as Landscaper does not guarantee any code mod's quality.